### PR TITLE
chore: relax six version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=1.4.3
 djangorestframework>=2.1.15
-six==1.5
+six>=1.5


### PR DESCRIPTION
https://app.asana.com/0/1201082158239874/1202228386516946

Since this package requires such a specific version of `six`, pip dependency resolution fails in Listener unless using `--no-deps`. As one small step toward getting pip to resolve all dependencies vs. using `--no-deps`, we need to relax the version requirement for `six` here.

```
#0 267.9 ERROR: Cannot install -r requirements.txt (line 10), -r requirements.txt (line 102), -r requirements.txt (line 107), -r requirements.txt (line 119), -r requirements.txt (line 120), -r requirements.txt (line 123), -r requirements.txt (line 129), -r requirements.txt (line 132), -r requirements.txt (line 134), -r requirements.txt (line 147), -r requirements.txt (line 152), -r requirements.txt (line 154), -r requirements.txt (line 155), -r requirements.txt (line 156), -r requirements.txt (line 163), -r requirements.txt (line 173), -r requirements.txt (line 27), -r requirements.txt (line 36), -r requirements.txt (line 39), -r requirements.txt (line 44), -r requirements.txt (line 46), -r requirements.txt (line 49), -r requirements.txt (line 57), -r requirements.txt (line 58), -r requirements.txt (line 59), -r requirements.txt (line 60), -r requirements.txt (line 63), -r requirements.txt (line 64), -r requirements.txt (line 65), -r requirements.txt (line 66), -r requirements.txt (line 67), -r requirements.txt (line 85), -r requirements.txt (line 93) and six==1.14.0 because these package versions have conflicting dependencies.
#0 267.9 
#0 267.9 The conflict is caused by:
#0 267.9     The user requested six==1.14.0
#0 267.9     bleach 3.3.0 depends on six>=1.9.0
#0 267.9     cryptography 3.3.2 depends on six>=1.4.1
#0 267.9     django-extensions 1.6.7 depends on six>=1.2
#0 267.9     django-migration-linter 3.0.1 depends on six>=1.14.0
#0 267.9     django-waffle 0.20.0 depends on six>=1.13.0
#0 267.9     ecdsa 0.15 depends on six>=1.9.0
#0 267.9     google-api-core 1.31.0 depends on six>=1.13.0
#0 267.9     google-api-python-client 2.13.0 depends on six<2dev and >=1.13.0
#0 267.9     google-auth 1.33.0 depends on six>=1.9.0
#0 267.9     google-auth-httplib2 0.1.0 depends on six
#0 267.9     gql 2.0.0 depends on six>=1.10.0
#0 267.9     graphene 2.1.8 depends on six<2 and >=1.10.0
#0 267.9     graphene-django 2.15.0 depends on six>=1.10.0
#0 267.9     graphql-core 2.3.2 depends on six>=1.10.0
#0 267.9     graphql-relay 2.0.1 depends on six>=1.12
#0 267.9     mock 2.0.0 depends on six>=1.9
#0 267.9     paste 2.0.3 depends on six>=1.4.0
#0 267.9     promise 2.3 depends on six
#0 267.9     pubnub 4.1.3 depends on six>=1.10
#0 267.9     pynacl 1.4.0 depends on six
#0 267.9     pyopenssl 18.0.0 depends on six>=1.5.2
#0 267.9     pysaml2 7.0.1 depends on six
#0 267.9     pytest-profiling 1.7.0 depends on six
#0 267.9     python-dateutil 2.8.1 depends on six>=1.5
#0 267.9     python-jose 3.1.0 depends on six<2.0
#0 267.9     responses 0.10.6 depends on six
#0 267.9     singledispatch 3.4.0.3 depends on six
#0 267.9     slackclient 1.2.1 depends on six<2.0a0 and >=1.10
#0 267.9     social-auth-app-django 1.1.0 depends on six
#0 267.9     social-auth-core 1.2.0 depends on six>=1.10.0
#0 267.9     twilio 6.37.0 depends on six
#0 267.9     websocket-client 0.48.0 depends on six
#0 267.9     djangorestframework-digestauth 1.1.0 depends on six==1.5
#0 267.9 
#0 267.9 To fix this you could try to:
#0 267.9 1. loosen the range of package versions you've specified
#0 267.9 2. remove package versions to allow pip attempt to solve the dependency conflict
#0 267.9 
#0 267.9 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```